### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-pipeline-build-tests.yml
+++ b/.github/workflows/ci-pipeline-build-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/ci-pipeline-build-tests.yml
+++ b/.github/workflows/ci-pipeline-build-tests.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Potential fix for [https://github.com/samuelemwangi/UserIdentity/security/code-scanning/2](https://github.com/samuelemwangi/UserIdentity/security/code-scanning/2)

In general, the fix is to explicitly define the least-privilege `permissions` for the workflow or for the specific job. Since this workflow just checks out code and runs .NET restore/build/test, it only needs read access to repository contents. We can therefore add `permissions: contents: read` at either the root of the workflow (affecting all jobs) or under the `build-tests` job. To minimize changes while clearly scoping the permissions to the affected job, we will add a `permissions` block inside the `build-tests` job.

Concretely, in `.github/workflows/ci-pipeline-build-tests.yml`, under `jobs: build-tests:` and aligned with `runs-on:`, insert:

```yaml
    permissions:
      contents: read
```

This ensures the `GITHUB_TOKEN` for this job is restricted to read-only access to repository contents, matching the minimal recommendation in the CodeQL warning. No additional imports, methods, or other definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
