### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-pipeline-publish-docker-image.yml
+++ b/.github/workflows/ci-pipeline-publish-docker-image.yml
@@ -1,5 +1,8 @@
 name: Publish Docker Image
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/samuelemwangi/UserIdentity/security/code-scanning/1](https://github.com/samuelemwangi/UserIdentity/security/code-scanning/1)

In general, the fix is to explicitly declare `permissions:` in the workflow (either at the top level or per job) and restrict `GITHUB_TOKEN` to the minimum scopes required. Since this workflow only checks out code and builds/pushes a Docker image to Docker Hub using secrets (and does not modify the GitHub repo, issues, or PRs), it typically only needs read access to repository contents.

The single best fix without changing functionality is to add a top-level `permissions:` block right after the `name:` or `on:` section in `.github/workflows/ci-pipeline-publish-docker-image.yml`, setting `contents: read`. This applies to all jobs that don’t override `permissions`, including `push-to-registry`. No other changes are required, and the existing steps using `actions/checkout`, docker login, metadata, and build/push will continue to work as before, since they only need read access to the repo plus the existing secrets for Docker Hub.

Concretely:
- Edit `.github/workflows/ci-pipeline-publish-docker-image.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  near the top (e.g., between `name: Publish Docker Image` and `on:`).  
- No imports, additional methods, or other definitions are needed because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
